### PR TITLE
Fix terminal size

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -9,9 +9,9 @@
 
 export class Terminal {
 
-    private static width: number;
+    private static width: number | null = null;
 
-    private static height: number;
+    private static height: number | null = null;
 
     private static defaultHeight: number = 50;
 


### PR DESCRIPTION
Cause of the uninitialized properties the method [`initDimensions`](https://github.com/media-service-dev/console/blob/master/src/Terminal.ts#L20) will never be called.

This behavior causes another bug that the section output overwrite will not clear all lines properly.